### PR TITLE
Fix Symfony cache generation between web / cli

### DIFF
--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         depends_on:
             - mysql
         volumes:
-            - "../../${PROJECT_DIRECTORY}:/var/www:cached"
+            - "../../${PROJECT_DIRECTORY}:/home/app/app:cached"
         labels:
             - "traefik.port=80"
             - "traefik.frontend.entryPoints=https"

--- a/infrastructure/docker/services/frontend/etc/nginx/nginx.conf
+++ b/infrastructure/docker/services/frontend/etc/nginx/nginx.conf
@@ -25,7 +25,7 @@ http {
 
     server {
         listen 0.0.0.0:80;
-        root /var/www/public;
+        root /home/app/app/public;
 
         location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg)$ {
             access_log off;


### PR DESCRIPTION
We now use the same absolute path between NGINX and workers to avoid Symfony regenerating the cache every time.

Ref
*  https://github.com/symfony/symfony/pull/32579
* https://github.com/symfony/symfony/issues/32599