### PR TITLE
Suggest warming up Symfony's cache

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -86,7 +86,7 @@ def cache_clear():
     """
     Clear cache of the frontend application
     """
-    # docker_compose_run('rm -rf var/cache/', no_deps=True)
+    # docker_compose_run('rm -rf var/cache/ && bin/console cache:warmup', no_deps=True)
 
 
 @task


### PR DESCRIPTION
This avoids permission issues when a Symfony Command running in another container (like a worker) is ran before the builder launch one.

Currently in my app, when running `fab start`, a worker seems to generate a prod cache on my host with `root` owner & group, thus causing cache issues on the remaining tasks of `fab start`