### PR TITLE
Rename down to destroy

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -135,7 +135,7 @@ def stop():
 
 @task
 @with_builder
-def down():
+def destroy():
     """
     Clean the infrastructure (remove container, volume, networks)
     """


### PR DESCRIPTION
I'm not sure about this one since `down` is the real name of the docker-compose command.

But `down` seems too soft. `destroy` is a bit scary, and it's intendeed since the user
can loose some data.

WDYT?