### PR TITLE
Rename 'builder' command by 'shell'

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -114,7 +114,7 @@ def migrate():
 
 @task
 @with_builder
-def builder():
+def shell():
     """
     Open a shell (bash) into a builder container
     """


### PR DESCRIPTION
Note: I tried to type `fab bash` and `fab shell` and it seems
`fab shell` is faster and easier (on AZERTY keyboard).

More over, it reflects more the reality