### PR TITLE
Hide nginx & PHP versions

### DIFF
--- a/infrastructure/docker/services/frontend/etc/nginx/nginx.conf
+++ b/infrastructure/docker/services/frontend/etc/nginx/nginx.conf
@@ -13,6 +13,7 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
     client_max_body_size 20m;
+    server_tokens off;
 
     gzip on;
     gzip_disable "msie6";

--- a/infrastructure/docker/services/frontend/etc/php7/conf.d/custom.ini
+++ b/infrastructure/docker/services/frontend/etc/php7/conf.d/custom.ini
@@ -1,0 +1,1 @@
+expose_php = off


### PR DESCRIPTION
In some projects, we use the docker-starter infrastructure in production, so let's hide those versions by default