### PR TITLE
Add quotes to docker-compose.yml path

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -178,7 +178,7 @@ def docker_compose(command_name):
     with shell_env(**localEnv):
         local('docker-compose -p %s %s %s' % (
             env.project_name,
-            ' '.join('-f ' + env.root_dir + '/infrastructure/docker/' + file for file in env.compose_files),
+            ' '.join('-f \'' + env.root_dir + '/infrastructure/docker/' + file + '\'' for file in env.compose_files),
             command_name
         ))
 


### PR DESCRIPTION
If one has spaces in one of his directory names, it would throw an error when installing the container.

Fixed by adding quotes around compose files path.