### PR TITLE
Add native support for workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,28 +297,21 @@ services:
 
 <summary>Read the cookbook</summary>
 
-In order to setup workers, you should add the following content to the `docker-compose.yml` file:
+In order to setup workers, you should define their service in the `docker-compose.worker.yml` file:
 
 ```yaml
-# this is a template to factorize the service definitions
-x-services-templates:
-    worker_base: &worker_base
-        build: services/frontend
-        depends_on:
-            - postgres
-        volumes:
-            - "../../${PROJECT_DIRECTORY}:/home/app/application:cached"
-        user: app
-        restart: unless-stopped
-
 services:
-    worker_date:
-        <<: *worker_base
-        command: watch -n 1 date
     worker_my_worker:
         <<: *worker_base
         command: /home/app/application/my-worker
+
+    worker_date:
+        <<: *worker_base
+        command: watch -n 1 date
 ```
+
+You also need to fill the `fabfile.py` to fill the tasks `start_workers` and `stop_workers`.
+These tasks currently propose default examples to use with Symfony Messenger.
 
 </details>
 

--- a/infrastructure/docker/docker-compose.worker.yml
+++ b/infrastructure/docker/docker-compose.worker.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+
+# this is a template to factorize the service definitions
+x-services-templates:
+    worker_base: &worker_base
+        build: services/worker
+        depends_on:
+            - postgres
+            #- rabbitmq
+        volumes:
+            - "../../${PROJECT_DIRECTORY}:/home/app/application:cached"
+        user: app
+        restart: unless-stopped
+
+#services:
+#    # Worker service names must start by "worker_"
+#
+#    worker_messenger:
+#        <<: *worker_base
+#        command: php -d memory_limit=1G /home/app/application/bin/console messenger:consume async --memory-limit=128M

--- a/infrastructure/docker/services/worker/Dockerfile
+++ b/infrastructure/docker/services/worker/Dockerfile
@@ -1,0 +1,5 @@
+ARG PROJECT_NAME
+
+FROM ${PROJECT_NAME}_php-base
+
+WORKDIR /home/app/application


### PR DESCRIPTION
This PR add native support for worker on the Docker infrastructure. Workers are stopped before running dependencies installation, database updates. They are started only when everything else is ready.

ATM Fabric tasks and Docker services show examples to use with symfony/messenger.

