### PR TITLE
Fix addgroup ambigous -g option

### DIFF
--- a/infrastructure/docker/services/php-base/Dockerfile
+++ b/infrastructure/docker/services/php-base/Dockerfile
@@ -37,7 +37,7 @@ RUN apk add --no-cache \
 # Install fake user app
 ARG USER_ID
 
-RUN addgroup -g 1000 app && \
+RUN addgroup --gid 1000 app && \
     adduser -S -u $USER_ID -h /home/app -s /bin/bash app
 
 # Configuration


### PR DESCRIPTION
When running docker-starter I got the following error:
```bash
Step 5/6 : RUN addgroup -g 1000 app &&     adduser -S -u $USER_ID -h /home/app -s /bin/bash app
 ---> Running in 69ca62b05233
Option g is ambiguous (gecos, gid, group)
adduser [--home DIR] [--shell SHELL] [--no-create-home] [--uid ID]
[--firstuid ID] [--lastuid ID] [--gecos GECOS] [--ingroup GROUP | --gid ID]
[--disabled-password] [--disabled-login] [--add_extra_groups] USER
   Add a normal user

adduser --system [--home DIR] [--shell SHELL] [--no-create-home] [--uid ID]
[--gecos GECOS] [--group | --ingroup GROUP | --gid ID] [--disabled-password]
[--disabled-login] [--add_extra_groups] USER
   Add a system user

adduser --group [--gid ID] GROUP
addgroup [--gid ID] GROUP
   Add a user group

addgroup --system [--gid ID] GROUP
   Add a system group

adduser USER GROUP
   Add an existing user to an existing group

general options:
  --quiet | -q      don't give process information to stdout
  --force-badname   allow usernames which do not match the
                    NAME_REGEX configuration variable
  --help | -h       usage message
  --version | -v    version number and copyright
  --conf | -c FILE  use FILE as configuration file

ERROR: Service 'php-base' failed to build: The command '/bin/sh -c addgroup -g 1000 app &&     adduser -S -u $USER_ID -h /home/app -s /bin/bash app' returned a non-zero code: 1
```

So I replaced `-g` by `--gid` and everything worked fine :tada: