### PR TITLE
Fix adduser ambigous options

### DIFF
--- a/infrastructure/docker/services/php-base/Dockerfile
+++ b/infrastructure/docker/services/php-base/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --no-cache \
 ARG USER_ID
 
 RUN addgroup --gid 1000 app && \
-    adduser -S -u $USER_ID -h /home/app -s /bin/bash app
+    adduser --system --uid $USER_ID --home /home/app --shell /bin/bash app
 
 # Configuration
 COPY *.ini /etc/php7/conf.d/


### PR DESCRIPTION
With a `debian:buster-slim` docker image, we can't use `adduser` shortcuts for some reason, so I'm just using options full names.

I tried it on `alpine:3.11` and it was working as well :wink: