### PR TITLE
Add --remove-orphans to the "up" command

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -63,7 +63,7 @@ def up():
     compose_files = env.compose_files
     env.compose_files = [file for file in compose_files if file != 'docker-compose.worker.yml']
 
-    docker_compose('up -d')
+    docker_compose('up --remove-orphans -d')
 
     env.compose_files = compose_files
 


### PR DESCRIPTION
Allow to avoid this king of warning:

> WARNING: Found orphan containers for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.