### PR TITLE
Refactor workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ services:
         command: watch -n 1 date
 ```
 
-You also need to fill the `fabfile.py` to fill the tasks `start_workers` and `stop_workers`.
-These tasks currently propose default examples to use with Symfony Messenger.
+You can also customize how the workers are stopped by editing the `stop_workers` task in `fabfile.py`.
+This task currently propose a default examples to use with Symfony Messenger.
 
 </details>
 

--- a/infrastructure/docker/docker-compose.worker.yml
+++ b/infrastructure/docker/docker-compose.worker.yml
@@ -10,7 +10,8 @@ x-services-templates:
         volumes:
             - "../../${PROJECT_DIRECTORY}:/home/app/application:cached"
         user: app
-        restart: unless-stopped
+        labels:
+            - "docker-starter.worker.${PROJECT_NAME}"
 
 #services:
 #    # Worker service names must start by "worker_"

--- a/infrastructure/docker/services/worker/Dockerfile
+++ b/infrastructure/docker/services/worker/Dockerfile
@@ -3,3 +3,7 @@ ARG PROJECT_NAME
 FROM ${PROJECT_NAME}_php-base
 
 WORKDIR /home/app/application
+
+COPY entrypoint.sh /var/lib
+
+ENTRYPOINT ["/var/lib/entrypoint.sh"]

--- a/infrastructure/docker/services/worker/entrypoint.sh
+++ b/infrastructure/docker/services/worker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ "$PROJECT_START_WORKERS" = "False" ]; then
+    echo "Worker not started"
+    exit 0
+fi
+
+exec "$@"


### PR DESCRIPTION
As discussed internally, the current implementation of workers had a few drawbacks:
- workers were not always build, so we had to remove the  `--remove-orphans` from the docker-compose up command
- worker service names were required to start with `worker_`

This is all fixed with this PR:
- Worker containers are now always build so we can make the `--remove-orphans` argument back again (supercedes #60)
- A variable environment and a docker entrypoint allow to build worker containers without running them (useful when building the whole app)
- A label is used to find worker containers, instead of using their name