### PR TITLE
Change threshold of PHP memory_limit: CLI: 512Mb, FPM: 128Mb

### DIFF
--- a/infrastructure/docker/services/frontend/etc/php7/conf.d/custom.ini
+++ b/infrastructure/docker/services/frontend/etc/php7/conf.d/custom.ini
@@ -1,1 +1,2 @@
-expose_php = off
+expose_php=off
+memory_limit=128M

--- a/infrastructure/docker/services/php-base/app.ini
+++ b/infrastructure/docker/services/php-base/app.ini
@@ -1,3 +1,4 @@
 date.timezone=Europe/Paris
 upload_max_filesize=20M
 post_max_size=20M
+memory_limit=512M


### PR DESCRIPTION
This will avoid unexpected exit for memory limit while, for instance, `bin/console clear:cache`