### PR TITLE
Improve the Maildev recipe with the DSN to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ Then, you will be able to browse:
 
 * `https://maildev.<root_domain>`
 
+> You can then configure your development mailer to send SMTP emails to the `maildev` host. For exemple with Symfony: `MAILER_DSN=smtp://maildev:25`.
+
 </details>
 
 ### How to add Mercure


### PR DESCRIPTION
Adding Maildev is not enough, you have to configure your app to send mails to it.

So let's add the proper DSN to the recipe for easy copy and paste!

```
MAILER_DSN=smtp://maildev:25
```