### PR TITLE
Update the Doctrine Migration command to allow no migration

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -79,7 +79,7 @@ def migrate(c):
     """
     # with Builder(c):
     #     docker_compose_run(c, 'php bin/console doctrine:database:create --if-not-exists')
-    #     docker_compose_run(c, 'php bin/console doctrine:migration:migrate -n')
+    #     docker_compose_run(c, 'php bin/console doctrine:migration:migrate -n --allow-no-migration')
 
 
 @task


### PR DESCRIPTION
There is a change in Doctrine Migration 3 that break the logic of being able to run "migrate" multiple times successfully.

See https://github.com/doctrine/migrations/issues/987

Without the flag it throw an error now:

> [ERROR] The version "latest" couldn't be reached, you are at version "DoctrineMigrations\Version20200616140303"

With the flag:

>  [WARNING] The version "latest" couldn't be reached, you are at version  "DoctrineMigrations\Version20200616140303"