### PR TITLE
Add unzip as dependency in builder

### DIFF
--- a/infrastructure/docker/services/builder/Dockerfile
+++ b/infrastructure/docker/services/builder/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         make \
         nodejs \
         sudo \
+        unzip \
     && apt-get clean \
     && npm install -g yarn \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*


### PR DESCRIPTION
`simple-phpunit` recommends `unzip`:

> As there is no 'unzip' command installed zip files are being unpacked using the PHP zip extension.
> This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.
> Installing 'unzip' may remediate them.

