### PR TITLE
Force Python 3 when there are multiple python installed

### DIFF
--- a/README.dist.md
+++ b/README.dist.md
@@ -12,7 +12,7 @@ A Docker environment is provided and requires you to have these tools available:
 Install and run `pipenv` to install the required tools:
 
 ```bash
-pipenv install
+pipenv --three install
 ```
 
 You can configure your current shell to be able to use Invoke commands directly


### PR DESCRIPTION
I have Python 2 and 3 installed locally and my "python" command line could be either of those versions. But `pipenv` is smart enough to look for Python 3 directly when using the `--three` option.

This avoid error like:

> Warning: Your Pipfile requires python_version 3, but you are using 2.7.15+ (/home/d/.local/share/v/d/bin/python).
