### PR TITLE
Make infrastructure working when used as root

### DIFF
--- a/invoke.py
+++ b/invoke.py
@@ -75,6 +75,10 @@ def __extract_runtime_configuration(config):
     if config['user_id'] > 256000:
         config['user_id'] = 1000
 
+    if config['user_id'] == 0:
+        print(Fore.YELLOW + 'Running as root? Fallback to fake user id.')
+        config['user_id'] = 1000
+
     return config
 
 


### PR DESCRIPTION
In some CI environment, the infrastructure uses root user but the build will fail with this error:
```
adduser: The UID 0 is already in use.
```

Should we support using the infrastructure with root user?

Kudos to @damienalexandre for the original fix