### PR TITLE
Change the crontab example

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ CMD ["cron", "-f"]
 
 And you can add all your crons in the `services/cron/crontab` file:
 ```crontab
-* * * * * su app -c "/usr/local/bin/php -r 'echo time();'" > /proc/1/fd/1 2>&1
+* * * * * su app -c "/usr/local/bin/php -r 'echo time().PHP_EOL;'" > /proc/1/fd/1 2>&1
 ```
 
 Finally, add the following content to the `docker-compose.yml` file:

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ CMD ["cron", "-f"]
 
 And you can add all your crons in the `services/cron/crontab` file:
 ```crontab
-* * * * * su app -c "php -r 'echo time();'" >> /var/log/cron
+* * * * * su app -c "/usr/local/bin/php -r 'echo time();'" > /proc/1/fd/1 2>&1
 ```
 
 Finally, add the following content to the `docker-compose.yml` file:


### PR DESCRIPTION
I had no logs when running `inv logs` so I guess the `>> /var/log/cron` was not working.

I search for a better output redirect and found this. It works on my project but I suggest reviewer test for themself.

Also, the `php` command was not found. I have no idea why (maybe cron is run in another shell?) but with the full path it's ok.

And finally adding `PHP_EOL` is needed to trigger display for this example (if there is no new line, the log is never finished and thus, not displayed).