### PR TITLE
Fix potential permission issue with /home/app/.composer folder in builder container

### DIFF
--- a/infrastructure/docker/services/builder/Dockerfile
+++ b/infrastructure/docker/services/builder/Dockerfile
@@ -31,5 +31,7 @@ RUN adduser app sudo \
 
 # Composer
 COPY --from=composer/composer:2.0.7 /usr/bin/composer /usr/bin/composer
+RUN mkdir -p "/home/app/.composer/cache" \
+    && chown app: /home/app/.composer -R
 
 WORKDIR /home/app/application


### PR DESCRIPTION
You may need to use the following command to fix the issue
```
docker volume rm starfleet_builder-data
```

or simply run
```
sudo chmod app: /home/app/.composer
```