### PR TITLE
fix the grabbing of the sury repo key

### DIFF
--- a/infrastructure/docker/services/php-base/Dockerfile
+++ b/infrastructure/docker/services/php-base/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         gnupg \
     && echo "deb https://packages.sury.org/php buster main" > /etc/apt/sources.list.d/sury.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B188E2B695BD4743
+    && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
see https://www.patreon.com/posts/dpa-new-signing-25451165

Else, we get an error since this morning: 
```
W: GPG error: https://packages.sury.org/php buster InRelease: The following signatures were invalid: EXPKEYSIG B188E2B695BD4743 DEB.SURY.ORG Automatic Signing Key <deb@sury.org>
```