### PR TITLE
Remove python + pip cache from Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,6 @@ jobs:
                     path: ~/.composer/cache/
                     key: "composer-${{ hashFiles('**/composer.lock') }}"
                     restore-keys: composer-
-            -
-                name: 'Cache Pipenv'
-                uses: actions/cache@v2
-                with:
-                    path: |
-                        ~/.cache/pip
-                        ~/.cache/pipenv
-                    key: "pip-pipenv-${{ hashFiles('**/Pipfile.lock') }}"
-                    restore-keys: |
-                        pip-pipenv-
 
             # Setup
 


### PR DESCRIPTION
The cache does not work well because of some python version: When github update python, it breaks the cache.
So we must remove the pipenv cache (see #135).

On other build, `pip3 install pipenv` step takes about 30 secondes. It's the same for this build. So the cache is useless. That's why I propose this PR: Less code == less bug.

Note: Another solution would be to revert partially #135 and to put the python version in the cache key and test if it's better. But it's more painful to maintain, and anyway we can not save more than 30 sec... Do we really want such pain in the ass? 