### PR TITLE
Fix the version of our debian base image to avoid confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update PHP to version 8.0
 * Update Composer to version 2.0.13
 * Fix APT key for Sury repository
+* Tag a strict version for the Debian base image
 
 ## 3.2.0 (2021-02-17)
 

--- a/infrastructure/docker/services/php-base/Dockerfile
+++ b/infrastructure/docker/services/php-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:10.9-slim
 
 RUN apt-get update \
     && apt install -y --no-install-recommends \


### PR DESCRIPTION
`debian:buster-slim` can be a lot of different images depending on when it was first downloaded, and sometimes a developer can have an old version in it's local Docker cache that is incompatible with what we use next.

So I'm now using a tagged `debian:10.9-slim` that we will need to upgrade from time to time, same as what we do with Composer i.e.