### PR TITLE
Ensure COMPOSER_CACHE_DIR will have default value

### DIFF
--- a/invoke.py
+++ b/invoke.py
@@ -40,6 +40,7 @@ def __extract_runtime_configuration(config):
     if os.path.exists(config['root_dir'] + '/infrastructure/docker/docker-compose.override.yml'):
         config['docker_compose_files'] += ['docker-compose.override.yml']
 
+    config['composer_cache_dir'] = composer_cache_dir
     composer_cache_dir = run('composer global config cache-dir -q', warn=True, hide=True).stdout
     if composer_cache_dir:
         config['composer_cache_dir'] = composer_cache_dir.strip()

--- a/invoke.py
+++ b/invoke.py
@@ -41,9 +41,9 @@ def __extract_runtime_configuration(config):
         config['docker_compose_files'] += ['docker-compose.override.yml']
 
     config['composer_cache_dir'] = composer_cache_dir
-    composer_cache_dir = run('composer global config cache-dir -q', warn=True, hide=True).stdout
-    if composer_cache_dir:
-        config['composer_cache_dir'] = composer_cache_dir.strip()
+    composer_cache_dir_from_host = run('composer global config cache-dir -q', warn=True, hide=True).stdout
+    if composer_cache_dir_from_host:
+        config['composer_cache_dir'] = composer_cache_dir_from_host.strip()
 
     if platform == "darwin":
         try:


### PR DESCRIPTION
Without it, `COMPOSER_CACHE_DIR` could be equals to `null` (if `composer` is not installed on host), and `composer` in builder container will never save cache.