### PR TITLE
Fix COPY issue with Docker For Mac

### DIFF
--- a/infrastructure/docker/services/frontend/Dockerfile
+++ b/infrastructure/docker/services/frontend/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
 
 RUN useradd -s /bin/false nginx
 
-COPY etc/. /etc/
+COPY etc/nginx/. /etc/nginx/
+COPY etc/service/. /etc/service/
 COPY php-configuration /etc/php/${PHP_VERSION}
 
 RUN phpenmod app-default \


### PR DESCRIPTION
From Docker 20.10.5, as described [here](https://github.com/moby/moby/issues/42148), the `COPY etc/. /etc/` was failing because `/etc` contains some symlinks


```
 => ERROR [4/6] COPY etc/. /etc/                                                                                                                                              0.0s
------
 > [4/6] COPY etc/. /etc/:
------
cannot copy to non-directory: /var/lib/docker/overlay2/nbwsg1pvx6x9hd2xaeloh39sc/merged/etc/service
ERROR: Service 'frontend' failed to build
```