### PR TITLE
Upgrade NodeJS to version 16.x LTS and remove deprecated apt-key usage

### DIFF
--- a/infrastructure/docker/services/builder/Dockerfile
+++ b/infrastructure/docker/services/builder/Dockerfile
@@ -2,14 +2,13 @@ ARG PROJECT_NAME
 
 FROM ${PROJECT_NAME}_php-base
 
-ARG NODEJS_VERSION=14.x
-RUN echo "deb https://deb.nodesource.com/node_${NODEJS_VERSION} bullseye main" > /etc/apt/sources.list.d/nodejs.list \
-    && apt-key adv --fetch-keys https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+ARG NODEJS_VERSION=16.x
+RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > /usr/share/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODEJS_VERSION} bullseye main" > /etc/apt/sources.list.d/nodejs.list
 
 # Default toys
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl \
         git \
         make \
         nodejs \

--- a/infrastructure/docker/services/php-base/Dockerfile
+++ b/infrastructure/docker/services/php-base/Dockerfile
@@ -2,10 +2,11 @@ FROM debian:11.0-slim
 
 RUN apt-get update \
     && apt install -y --no-install-recommends \
+        curl \
         ca-certificates \
         gnupg \
-    && echo "deb https://packages.sury.org/php bullseye main" > /etc/apt/sources.list.d/sury.list \
-    && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg
+    && curl -s https://packages.sury.org/php/apt.gpg | gpg --dearmor > /usr/share/keyrings/deb.sury.org-php.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php bullseye main" > /etc/apt/sources.list.d/sury.list
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Switch to current LTS version of NodeJS and use keyrings files directly instead of now deprecated apt-key usage