### PR TITLE
Fix the npm/yarn install for mac users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add documentation cookbook for using pg_activity
 * Forward CI env vars in Docker containers
+* Run the npm/yarn/webpack commands on the host for all mac users (even the ones not using Dinghy)
 
 ## 3.7.0 (2022-05-24)
 

--- a/invoke.py
+++ b/invoke.py
@@ -20,6 +20,7 @@ services_to_build_first = [
     'builder',
 ]
 dinghy = False
+macos = False
 power_shell = False
 user_id = 1000
 root_dir = '.'
@@ -46,6 +47,8 @@ def __extract_runtime_configuration(config):
         config['composer_cache_dir'] = composer_cache_dir_from_host.strip()
 
     if platform == "darwin":
+        config['macos'] = True
+
         try:
             docker_kernel = run('docker version --format "{{.Server.KernelVersion}}"', hide=True).stdout
         except:

--- a/tasks.py
+++ b/tasks.py
@@ -68,9 +68,9 @@ def install(c):
         if os.path.isfile(c.root_dir + '/' + c.project_directory + '/composer.json'):
             docker_compose_run(c, 'composer install -n --prefer-dist --optimize-autoloader', no_deps=True)
         if os.path.isfile(c.root_dir + '/' + c.project_directory + '/yarn.lock'):
-            run_in_docker_or_locally_for_dinghy(c, 'yarn', no_deps=True)
+            run_in_docker_or_locally_for_mac(c, 'yarn', no_deps=True)
         elif os.path.isfile(c.root_dir + '/' + c.project_directory + '/package.json'):
-            run_in_docker_or_locally_for_dinghy(c, 'npm install', no_deps=True)
+            run_in_docker_or_locally_for_mac(c, 'npm install', no_deps=True)
 
 
 @task
@@ -244,11 +244,11 @@ def generate_certificates(c, force=False):
             print('Please restart the infrastructure to use the new certificates with "inv up" or "inv start".')
 
 
-def run_in_docker_or_locally_for_dinghy(c, command, no_deps=False):
+def run_in_docker_or_locally_for_mac(c, command, no_deps=False):
     """
     Mac users have a lot of problems running Yarn / Webpack on the Docker stack so this func allow them to run these tools on their host
     """
-    if c.dinghy:
+    if c.macos:
         with c.cd(c.project_directory):
             c.run(command)
     else:


### PR DESCRIPTION
Most of our mac users don't use anymore Dinghy but have still some troubles with running yarn / webpack on the Docker stack.

This change allow every mac users to execute npm/yarn commands on their host instead of within docker, regardless of if they are using Dinghy or Docker Desktop.