### PR TITLE
fix(workers tasks): get_workers works with docker ps header

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -313,6 +313,9 @@ def get_workers(c):
     Find worker containers for the current project
     """
     cmd = c.run('docker ps -a --filter "label=docker-starter.worker.%s" --quiet' % c.project_name, hide='both')
+    if re.compile('^NAMES').search(cmd.stdout):
+        return list(filter(None, cmd.stdout.rsplit("\n")))[1::]
+
     return list(filter(None, cmd.stdout.rsplit("\n")))
 
 


### PR DESCRIPTION
Hi there,

Thanks for this awesome tool folks!

I have an issue with the `get_workers` function, I think it's from a new docker version, but not sure. /shrug
```
$ docker --version
Docker version 23.0.6

$ inv start 
Encountered a bad command exit code!

Command: 'docker update --restart=no NAMES     IMAGE     CREATED ago   STATUS    COMMAND'

Exit code: 1

Stdout:



Stderr:

Error response from daemon: No such container: NAMES
Error response from daemon: No such container: IMAGE
Error response from daemon: No such container: CREATED
Error response from daemon: No such container: ago
Error response from daemon: No such container: STATUS
Error response from daemon: No such container: COMMAND

$ docker ps -a --filter "label=docker-starter.worker.lookcycle" --quiet
NAMES     IMAGE     CREATED ago   STATUS    COMMAND
```

I've updated the function to check if the header is displayed. (Maybe a better way to do this?)
