### PR TITLE
feat(nodejs): Use NodeJS 18.x LTS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.10.0 (not released yet)
 
 * Fix workers detection in docker v23
+* Use NodeJS 18.x LTS version
 
 ## 3.9.0 (2022-12-21)
 

--- a/infrastructure/docker/services/builder/Dockerfile
+++ b/infrastructure/docker/services/builder/Dockerfile
@@ -2,7 +2,7 @@ ARG PROJECT_NAME
 
 FROM ${PROJECT_NAME}_php-base
 
-ARG NODEJS_VERSION=16.x
+ARG NODEJS_VERSION=18.x
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > /usr/share/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODEJS_VERSION} bullseye main" > /etc/apt/sources.list.d/nodejs.list
 


### PR DESCRIPTION
NodeJS 18.x is the LTS version since 2022-10-25