### PR TITLE
Update maildev instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Upgrade to PostgreSQL v15
 * Update base Debian version to 11.7
 * Dynamically map user id and group id to the container, base on the host user
+* Update maildev instructions
 
 ## 3.11.0 (2023-05-30)
 

--- a/README.md
+++ b/README.md
@@ -404,8 +404,10 @@ to the `docker-compose.yml` file:
 ```yaml
 services:
     maildev:
-        image: djfarrelly/maildev
-        command: ["bin/maildev", "--web", "80", "--smtp", "25", "--hide-extensions", "STARTTLS"]
+        image: maildev/maildev
+        environment:
+            - MAILDEV_WEB_PORT=80
+            - MAILDEV_SMTP_PORT=25
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.${PROJECT_NAME}-maildev.rule=Host(`maildev.${PROJECT_ROOT_DOMAIN}`)"


### PR DESCRIPTION
djfarrelly/maildev was deprecated and not updated for more than 4 years so let's use the now official maildev image

Also, since https://github.com/maildev/maildev/pull/276, STARTTLS should be disabled by default so no need to disable it.