### PR TITLE
Add aliases on most commonly used tasks

### DIFF
--- a/.castor/infra.php
+++ b/.castor/infra.php
@@ -50,7 +50,7 @@ function stop(): void
     docker_compose(['stop']);
 }
 
-#[AsTask(description: 'Opens a shell (bash) into a builder container')]
+#[AsTask(description: 'Opens a shell (bash) into a builder container', aliases: ['builder'])]
 function builder(): void
 {
     $c = get_context()
@@ -63,19 +63,19 @@ function builder(): void
     docker_compose_run('bash', c: $c);
 }
 
-#[AsTask(description: 'Displays infrastructure logs')]
+#[AsTask(description: 'Displays infrastructure logs', aliases: ['logs'])]
 function logs(): void
 {
     docker_compose(['logs', '-f', '--tail', '150'], c: get_context()->withTty());
 }
 
-#[AsTask(description: 'Lists containers status')]
+#[AsTask(description: 'Lists containers status', aliases: ['ps'])]
 function ps(): void
 {
     docker_compose(['ps'], withBuilder: false);
 }
 
-#[AsTask(description: 'Cleans the infrastructure (remove container, volume, networks)')]
+#[AsTask(description: 'Cleans the infrastructure (remove container, volume, networks)', aliases: ['destroy'])]
 function destroy(
     #[AsOption(description: 'Force the destruction without confirmation', shortcut: 'f')]
     bool $force = false,
@@ -164,7 +164,7 @@ function generate_certificates(
     }
 }
 
-#[AsTask(description: 'Starts the workers', namespace: 'infra:worker', name: 'start')]
+#[AsTask(description: 'Starts the workers', namespace: 'infra:worker', name: 'start', aliases: ['start-workers'])]
 function workers_start(): void
 {
     $workers = get_workers();
@@ -187,7 +187,7 @@ function workers_start(): void
     ], quiet: true);
 }
 
-#[AsTask(description: 'Stops the workers', namespace: 'infra:worker', name: 'stop')]
+#[AsTask(description: 'Stops the workers', namespace: 'infra:worker', name: 'stop', aliases: ['stop-workers'])]
 function workers_stop(): void
 {
     $workers = get_workers();

--- a/.castor/qa.php
+++ b/.castor/qa.php
@@ -19,13 +19,13 @@ function install(): void
     docker_compose_run('composer install -o', workDir: '/home/app/root/tools/phpstan');
 }
 
-#[AsTask(description: 'Runs PHPStan')]
+#[AsTask(description: 'Runs PHPStan', aliases: ['phpstan'])]
 function phpstan(): void
 {
     docker_compose_run('phpstan --configuration=/home/app/root/phpstan.neon', workDir: '/home/app/application');
 }
 
-#[AsTask(description: 'Fixes Coding Style')]
+#[AsTask(description: 'Fixes Coding Style', aliases: ['cs'])]
 function cs(bool $dryRun = false): void
 {
     if ($dryRun) {

--- a/castor.php
+++ b/castor.php
@@ -46,7 +46,7 @@ function start(): void
     about();
 }
 
-#[AsTask(description: 'Installs the application (composer, yarn, ...)', namespace: 'app')]
+#[AsTask(description: 'Installs the application (composer, yarn, ...)', namespace: 'app', aliases: ['install'])]
 function install(): void
 {
     $basePath = sprintf('%s/%s', variable('root_dir'), variable('project_directory'));
@@ -63,13 +63,13 @@ function install(): void
     qa\install();
 }
 
-#[AsTask(description: 'Clear the application cache', namespace: 'app')]
+#[AsTask(description: 'Clear the application cache', namespace: 'app', aliases: ['cache-clear'])]
 function cache_clear(): void
 {
     // docker_compose_run('rm -rf var/cache/ && bin/console cache:warmup');
 }
 
-#[AsTask(description: 'Migrates database schema', namespace: 'app:db')]
+#[AsTask(description: 'Migrates database schema', namespace: 'app:db', aliases: ['migrate'])]
 function migrate(): void
 {
     // docker_compose_run('bin/console doctrine:database:create --if-not-exists');


### PR DESCRIPTION
This PR adds aliases on many tasks to help people annoyed by the namespaces.

In the past, we used Invoke, for which we didn't use namespaces. Migrating from Invoke to Castor makes using the namespace a bit clunky, even if they are quite handy as don't need to write them fully. Some people (including myself, as you may have guessed) are used to the old commands and would be pleased to have them back!

Since this does not change anything for the namespaces users, I think this should not be a problem.