### PR TITLE
Configure some dotenv when installing Symfony

### DIFF
--- a/.castor/init.php
+++ b/.castor/init.php
@@ -38,6 +38,8 @@ function symfony(bool $webApp = false): void
     if ($webApp) {
         docker_compose_run('composer require webapp');
     }
+
+    docker_compose_run("sed -i 's#^DATABASE_URL.*#DATABASE_URL=postgresql://app:app@postgres:5432/app\?serverVersion=16\&charset=utf8#' .env");
     file_put_contents($gitIgnore, $gitIgnoreContent, FILE_APPEND);
 
     fs()->remove($base . '/sf');


### PR DESCRIPTION
Replace the manual instruction we had previously in the cookbook https://github.com/jolicode/docker-starter/commit/19df2323a8b4953798efb29c15e7208fe249bfc1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127