### PR TITLE
Build before Symfony project creation

### DIFF
--- a/.castor/init.php
+++ b/.castor/init.php
@@ -2,7 +2,6 @@
 
 use Castor\Attribute\AsTask;
 
-use function Castor\finder;
 use function Castor\fs;
 use function Castor\variable;
 
@@ -31,6 +30,7 @@ function symfony(bool $webApp = false): void
         $gitIgnoreContent = file_get_contents($gitIgnore);
     }
 
+    infra\build();
     docker_compose_run('composer create-project symfony/skeleton sf');
 
     fs()->mirror($base . '/sf/', $base);


### PR DESCRIPTION
The `castor symfony` task fails as the `USER_ID` and `PHP_VERSION` args do not exist before the build.

I also remove an unused declaration.