### PR TITLE
Automatically replace hostnames in the README

### DIFF
--- a/.castor/init.php
+++ b/.castor/init.php
@@ -17,6 +17,11 @@ function init(): void
         __FILE__,
     ]);
     fs()->rename('README.dist.md', 'README.md');
+
+    $readMeContent = file_get_contents('README.md');
+    $urls = [variable('root_domain'), ...variable('extra_domains')];
+    $readMeContent = str_replace('<your hostnames>', implode(' ', $urls), $readMeContent);
+    file_put_contents('README.md', $readMeContent);
 }
 
 #[AsTask(description: 'Install Symfony')]


### PR DESCRIPTION
This automatically replace `<your hostnames>` in the domain configuration command by the domains define in the default parameters when executing `castor init` task.

e.g. : 
```
echo '127.0.0.1 app.test www.app.test' | sudo tee -a /etc/hosts
```
instead of
```
echo '127.0.0.1 <your hostnames>' | sudo tee -a /etc/hosts
```