### PR TITLE
Fix docker compose labels for workers

### DIFF
--- a/infrastructure/docker/docker-compose.worker.yml
+++ b/infrastructure/docker/docker-compose.worker.yml
@@ -12,7 +12,7 @@ x-services-templates:
         volumes:
             - "../..:/var/www:cached"
         labels:
-            - "docker-starter.worker.${PROJECT_NAME}"
+            - "docker-starter.worker.${PROJECT_NAME}=true"
 
 # services:
 #    worker_messenger:


### PR DESCRIPTION
Avoid the following error on some docker compose version:

```
* error decoding 'labels': invalid label ["docker-starter.worker.xxx"]
```

Seems related to https://github.com/docker/compose/issues/11133