### PR TITLE
Run the `importmap:install` command if the importmap.php file exists

### DIFF
--- a/castor.php
+++ b/castor.php
@@ -58,6 +58,9 @@ function install(): void
     } elseif (is_file("{$basePath}/package.json")) {
         docker_compose_run('npm install');
     }
+    if (is_file("{$basePath}/importmap.php")) {
+        docker_compose_run('bin/console importmap:install');
+    }
 
     qa\install();
 }


### PR DESCRIPTION
Fix #269 