### PR TITLE
Add array_unique on urls listing

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -51,7 +51,7 @@ function about(): void
             $urls = [...$urls, ...$hosts];
         }
     }
-    io()->listing(array_map(fn ($url) => "https://{$url}", $urls));
+    io()->listing(array_map(fn ($url) => "https://{$url}", array_unique($urls)));
 }
 
 #[AsTask(description: 'Opens the project in your browser', namespace: '', aliases: ['open'])]


### PR DESCRIPTION
When running `castor start`, on some projects, the same url is displayed multiple times, for instance : 

```
Available URLs for this project:
--------------------------------

 * https://foodomarket.local
 * https://elasticsearch.foodomarket.local
 * https://kibana.foodomarket.local
 * https://redis.foodomarket.local
 * https://foodomarket.local
 * https://foodomarket.local
```

=> "https://foodomarket.local" displayed 3 times