### PR TITLE
Remove `version` properties

### DIFF
--- a/infrastructure/docker/docker-compose.builder.yml
+++ b/infrastructure/docker/docker-compose.builder.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
     builder-data: {}
 

--- a/infrastructure/docker/docker-compose.docker-for-x.yml
+++ b/infrastructure/docker/docker-compose.docker-for-x.yml
@@ -1,7 +1,5 @@
 # This file is used only when using Docker for Mac or Windows
 
-version: '3.7'
-
 services:
     router:
         # Docker for Mac or Windows does not support the "network_mode=host"

--- a/infrastructure/docker/docker-compose.worker.yml
+++ b/infrastructure/docker/docker-compose.worker.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 # this is a template to factorize the service definitions
 x-services-templates:
     worker_base: &worker_base

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
     postgres-data: {}
 


### PR DESCRIPTION
This was informative only and now returns a `'version' is obsolete` warning, cf. https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements