### PR TITLE
Use only project container in traefik discovery

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -81,14 +81,12 @@ function build(
         $command[] = $profile;
     }
 
-    $userId = variable('user_id');
-    $phpVersion = variable('php_version');
-
     $command = [
         ...$command,
         'build',
-        '--build-arg', "USER_ID={$userId}",
-        '--build-arg', "PHP_VERSION={$phpVersion}",
+        '--build-arg', 'USER_ID=' . variable('user_id'),
+        '--build-arg', 'PHP_VERSION=' . variable('php_version'),
+        '--build-arg', 'PROJECT_NAME=' . variable('project_name'),
     ];
 
     if ($service) {

--- a/README.md
+++ b/README.md
@@ -187,9 +187,12 @@ If you want to use Webpack Encore in a Symfony project,
             command: "yarn run dev-server --hot --host 0.0.0.0 --allowed-hosts encore.${PROJECT_ROOT_DOMAIN} --allowed-hosts ${PROJECT_ROOT_DOMAIN} --client-web-socket-url-hostname encore.${PROJECT_ROOT_DOMAIN} --client-web-socket-url-port 443 --client-web-socket-url-protocol wss"
             labels:
                 - "traefik.enable=true"
+                - "project-name=${PROJECT_NAME}"
                 - "traefik.http.routers.${PROJECT_NAME}-encore.rule=Host(`encore.${PROJECT_ROOT_DOMAIN}`)"
                 - "traefik.http.routers.${PROJECT_NAME}-encore.tls=true"
                 - "traefik.http.services.encore.loadbalancer.server.port=8080"
+            profiles:
+                - default
     ```
 
 3. Update the webpack configuration to specify the asset location in **dev**:
@@ -296,8 +299,11 @@ services:
             - "discovery.type=single-node"
         labels:
             - "traefik.enable=true"
+            - "project-name=${PROJECT_NAME}"
             - "traefik.http.routers.${PROJECT_NAME}-elasticsearch.rule=Host(`elasticsearch.${PROJECT_ROOT_DOMAIN}`)"
             - "traefik.http.routers.${PROJECT_NAME}-elasticsearch.tls=true"
+        profiles:
+            - default
 
     kibana:
         image: kibana:7.8.0
@@ -305,8 +311,11 @@ services:
             - elasticsearch
         labels:
             - "traefik.enable=true"
+            - "project-name=${PROJECT_NAME}"
             - "traefik.http.routers.${PROJECT_NAME}-kibana.rule=Host(`kibana.${PROJECT_ROOT_DOMAIN}`)"
             - "traefik.http.routers.${PROJECT_NAME}-kibana.tls=true"
+        profiles:
+            - default
 ```
 
 Then, you will be able to browse:
@@ -391,9 +400,12 @@ services:
             - rabbitmq-data:/var/lib/rabbitmq
         labels:
             - "traefik.enable=true"
+            - "project-name=${PROJECT_NAME}"
             - "traefik.http.routers.${PROJECT_NAME}-rabbitmq.rule=Host(`rabbitmq.${PROJECT_ROOT_DOMAIN}`)"
             - "traefik.http.routers.${PROJECT_NAME}-rabbitmq.tls=true"
             - "traefik.http.services.rabbitmq.loadbalancer.server.port=15672"
+        profiles:
+            - default
 ```
 
 In order to publish and consume messages with PHP, you need to install the
@@ -440,8 +452,11 @@ services:
             - "redis-insight-data:/db"
         labels:
             - "traefik.enable=true"
+            - "project-name=${PROJECT_NAME}"
             - "traefik.http.routers.${PROJECT_NAME}-redis.rule=Host(`redis.${PROJECT_ROOT_DOMAIN}`)"
             - "traefik.http.routers.${PROJECT_NAME}-redis.tls=true"
+        profiles:
+            - default
 
 ```
 
@@ -477,9 +492,12 @@ services:
             - MAILDEV_SMTP_PORT=25
         labels:
             - "traefik.enable=true"
+            - "project-name=${PROJECT_NAME}"
             - "traefik.http.routers.${PROJECT_NAME}-maildev.rule=Host(`maildev.${PROJECT_ROOT_DOMAIN}`)"
             - "traefik.http.routers.${PROJECT_NAME}-maildev.tls=true"
             - "traefik.http.services.maildev.loadbalancer.server.port=80"
+        profiles:
+            - default
 ```
 
 Then, you will be able to browse:
@@ -516,8 +534,11 @@ services:
             - "CORS_ALLOWED_ORIGINS=*"
         labels:
             - "traefik.enable=true"
+            - "project-name=${PROJECT_NAME}"
             - "traefik.http.routers.${PROJECT_NAME}-mercure.rule=Host(`mercure.${PROJECT_ROOT_DOMAIN}`)"
             - "traefik.http.routers.${PROJECT_NAME}-mercure.tls=true"
+        profiles:
+            - default
 ```
 
 If you are using Symfony, you must put the following configuration in the `.env` file:
@@ -631,6 +652,8 @@ services:
             BLACKFIRE_SERVER_TOKEN: FIXME
             BLACKFIRE_CLIENT_ID: FIXME
             BLACKFIRE_CLIENT_TOKEN: FIXME
+        profiles:
+            - default
 
 ```
 
@@ -710,6 +733,8 @@ services:
             target: cron
         volumes:
             - "../..:/var/www:cached"
+        profiles:
+            - default
 ```
 
 </details>

--- a/infrastructure/docker/docker-compose.builder.yml
+++ b/infrastructure/docker/docker-compose.builder.yml
@@ -21,3 +21,5 @@ services:
             - "builder-data:/home/app"
             - "${COMPOSER_CACHE_DIR}:/home/app/.composer/cache"
             - "../..:/var/www:cached"
+        profiles:
+            - default

--- a/infrastructure/docker/docker-compose.docker-for-x.yml
+++ b/infrastructure/docker/docker-compose.docker-for-x.yml
@@ -9,3 +9,5 @@ services:
             - "80:80"
             - "443:443"
             - "8080:8080"
+        profiles:
+            - default

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
             - default
         labels:
             - "traefik.enable=true"
+            - "project-name=${PROJECT_NAME}"
             - "traefik.http.routers.${PROJECT_NAME}-frontend.rule=Host(${PROJECT_DOMAINS})"
             - "traefik.http.routers.${PROJECT_NAME}-frontend.tls=true"
             - "traefik.http.routers.${PROJECT_NAME}-frontend-unsecure.rule=Host(${PROJECT_DOMAINS})"

--- a/infrastructure/docker/services/router/Dockerfile
+++ b/infrastructure/docker/services/router/Dockerfile
@@ -2,4 +2,7 @@ FROM traefik:v3.0
 
 COPY traefik /etc/traefik
 
+ARG PROJECT_NAME
+RUN sed -i "s/{{ PROJECT_NAME }}/${PROJECT_NAME}/g" /etc/traefik/traefik.yaml
+
 VOLUME [ "/etc/ssl/certs" ]

--- a/infrastructure/docker/services/router/traefik/traefik.yaml
+++ b/infrastructure/docker/services/router/traefik/traefik.yaml
@@ -5,6 +5,7 @@ global:
 providers:
   docker:
     exposedByDefault: false
+    constraints: "Label(`project-name`,`{{ PROJECT_NAME }}`)"
   file:
     filename: /etc/traefik/dynamic_conf.yaml
 


### PR DESCRIPTION
Before this PR, traefik could discovery and **use** all running containers. Now it could use only containers defined in **this** application. This is mandatory if you want to run N times the very same project on a single machine (CI) and also use real internal URL (not docker alias)