### PR TITLE
Update user_id value in .castor/docker.php for Windows compatibility

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -310,7 +310,8 @@ function create_default_context(): Context
         ],
         'macos' => false,
         'power_shell' => false,
-        'user_id' => posix_geteuid(),
+        'user_id' => getmyuid(), // replaced posix_geteuid as posix isn't available in PHP windows
+        // Windows 11 PHP 8.3.6
         'root_dir' => \dirname(__DIR__),
     ];
 


### PR DESCRIPTION
posix_geteuid -> getmy_uid

posix_geteuid() function is not available on Windows, instead getmyuid() is supposed to be a platform independant way to get the current user ID.

The fix works on windows but I haven't tested on any unix system yet.

Before
![Capture d'écran 2024-04-19 132541](https://github.com/jolicode/docker-starter/assets/66386196/7ec04fab-4778-4008-9da6-b2039259faef)
![Capture d'écran 2024-04-19 132558](https://github.com/jolicode/docker-starter/assets/66386196/c816185e-2eba-4433-abec-76e670ddb5d4)

After
![Capture d'écran 2024-04-19 132445](https://github.com/jolicode/docker-starter/assets/66386196/8c03db20-5918-46d2-b642-a9bff2413f8f)

