### PR TITLE
Update platform value for windows devices as it returns windows nt

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -342,7 +342,7 @@ function create_default_context(): Context
     if (str_contains($platform, 'darwin')) {
         $data['macos'] = true;
         $data['docker_compose_files'][] = 'docker-compose.docker-for-x.yml';
-    } elseif (\in_array($platform, ['win32', 'win64'])) {
+    } elseif (\in_array($platform, ['win32', 'win64', 'windows nt'])) {
         $data['docker_compose_files'][] = 'docker-compose.docker-for-x.yml';
         $data['power_shell'] = true;
     }


### PR DESCRIPTION
Maybe it was changed on the latest version of PHP or Windows but the function php_uname('s') returns windows nt on my device not win32 nor win64.
![Capture d'écran 2024-04-22 084314](https://github.com/jolicode/docker-starter/assets/66386196/697d9497-37d0-49d1-87e0-e4856d4d9d7f)

This was preventing the use of the non-host network type for windows machine (docker-for-x) and by so no ports were forwarded.
It works now :
![Capture d'écran 2024-04-22 084402](https://github.com/jolicode/docker-starter/assets/66386196/4554f365-0951-4ef6-8fe8-5810582ca913)
