### PR TITLE
fix(npm): make sure we can always install dependencies

### DIFF
--- a/castor.php
+++ b/castor.php
@@ -74,7 +74,12 @@ function install(): void
         docker_compose_run('yarn install --frozen-lockfile');
     } elseif (is_file("{$basePath}/package.json")) {
         io()->section('Installing Node.js dependencies');
-        docker_compose_run('npm ci');
+
+        if (is_file("{$basePath}/package-lock.json")) {
+            docker_compose_run('npm ci');
+        } else {
+            docker_compose_run('npm install');
+        }
     }
     if (is_file("{$basePath}/importmap.php")) {
         io()->section('Installing importmap');


### PR DESCRIPTION
Got this error after deleting my package-lock.json:

> npm error code EUSAGE
> npm error
> npm error The `npm ci` command can only install with an existing package-lock.json or
> npm error npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or
> npm error later to generate a package-lock.json file, then try again.

I think it's sensible to run "npm install" when there is no lock file found.