### PR TITLE
Replace maildev with Mailpit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Do not store certificates in the router image
 * Upgrade to PostgreSQL v16
 * Dynamically map user id and group id to the container, base on the host user
-* Update maildev instructions
+* Replace maildev with Mailpit
 * Drop support for PHP < 8.1
 * Add support for PHP 8.3
 * Add some PHP tooling (PHP-CS-Fixer, PHPStan)

--- a/README.md
+++ b/README.md
@@ -474,43 +474,42 @@ In your application, you can use the following configuration:
 
 </details>
 
-### How to add Maildev
+### How to add Mailpit
 
 <details>
 
 <summary>Read the cookbook</summary>
 
-In order to use Maildev and its dashboard, you should add the following content
+In order to use Mailpit and its dashboard, you should add the following content
 to the `docker-compose.yml` file:
 
 ```yaml
 services:
-    maildev:
-        image: maildev/maildev
+    mail:
+        image: axllent/mailpit
         environment:
-            - MAILDEV_WEB_PORT=80
-            - MAILDEV_SMTP_PORT=25
+            - MP_SMTP_BIND_ADDR=0.0.0.0:25
         labels:
             - "traefik.enable=true"
             - "project-name=${PROJECT_NAME}"
-            - "traefik.http.routers.${PROJECT_NAME}-maildev.rule=Host(`maildev.${PROJECT_ROOT_DOMAIN}`)"
-            - "traefik.http.routers.${PROJECT_NAME}-maildev.tls=true"
-            - "traefik.http.services.maildev.loadbalancer.server.port=80"
+            - "traefik.http.routers.${PROJECT_NAME}-mail.rule=Host(`mail.${PROJECT_ROOT_DOMAIN}`)"
+            - "traefik.http.routers.${PROJECT_NAME}-mail.tls=true"
+            - "traefik.http.services.mail.loadbalancer.server.port=8025"
         profiles:
             - default
 ```
 
 Then, you will be able to browse:
 
-* `https://maildev.<root_domain>`
+* `https://mail.<root_domain>`
 
 In your application, you can use the following configuration:
 
 * scheme: `smtp`;
-* host: `maildev`;
+* host: `mail`;
 * port: `25`.
 
-For example in Symfony you can use: `MAILER_DSN=smtp://maildev:25`.
+For example in Symfony you can use: `MAILER_DSN=smtp://mail:25`.
 
 </details>
 


### PR DESCRIPTION
Maildev does not seem maintened anymore, and is currently broken with latest docker versions.

Let's now recommend Mailpit instead which is quite similar.
