### PR TITLE
Fix `FromAsCasing` build check

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ services:
 Add the following file `infrastructure/docker/services/redirectionio-agent/Dockerfile`:
 
 ```Dockerfile
-FROM alpine:3.12 as alpine
+FROM alpine:3.12 AS alpine
 
 WORKDIR /tmp
 
@@ -704,7 +704,7 @@ In order to set up crontab, you should add a new container:
 ```Dockerfile
 # services/php/Dockerfile
 
-FROM php-base as cron
+FROM php-base AS cron
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/infrastructure/docker/services/php/Dockerfile
+++ b/infrastructure/docker/services/php/Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3008
 
-FROM debian:12.5-slim as php-base
+FROM debian:12.5-slim AS php-base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -58,7 +58,7 @@ WORKDIR /var/www
 
 ENTRYPOINT [ "/entrypoint" ]
 
-FROM php-base as frontend
+FROM php-base AS frontend
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -82,9 +82,9 @@ EXPOSE 80
 
 CMD ["runsvdir", "-P", "/etc/service"]
 
-FROM php-base as worker
+FROM php-base AS worker
 
-FROM php-base as builder
+FROM php-base AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Since the latest versions of Docker the https://docs.docker.com/reference/build-checks/from-as-casing/ build check is applied, displaying warnings if not respected.