### PR TITLE
fix some issues with worker profile

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -49,7 +49,7 @@ function about(): void
             if ("frontend-{$projectName}" === $router['service']) {
                 continue;
             }
-            if (!preg_match('{^Host\\(`(?P<hosts>.*)`\\)$}', $router['rule'], $matches)) {
+            if (!preg_match('{^Host\(`(?P<hosts>.*)`\)$}', $router['rule'], $matches)) {
                 continue;
             }
             $hosts = explode('`) || Host(`', $matches['hosts']);
@@ -79,6 +79,11 @@ function build(
     if ($profile) {
         $command[] = '--profile';
         $command[] = $profile;
+    } else {
+        $command[] = '--profile';
+        $command[] = 'default';
+        $command[] = '--profile';
+        $command[] = 'worker';
     }
 
     $command = [

--- a/castor.php
+++ b/castor.php
@@ -46,7 +46,7 @@ function start(): void
     // workers_stop();
     generate_certificates(force: false);
     build();
-    up();
+    up(profiles: ['default']); // We can't start worker now, they are not installed
     cache_clear();
     install();
     migrate();

--- a/infrastructure/docker/docker-compose.worker.yml
+++ b/infrastructure/docker/docker-compose.worker.yml
@@ -4,8 +4,7 @@ x-services-templates:
         build:
             context: services/php
             target: worker
-        # Don't use depends_on, it does not work well when stopping containers
-        # with docker compose profiles
+        # Don't use depends_on, it does not work well with docker compose profiles
         volumes:
             - "../..:/var/www:cached"
         profiles:


### PR DESCRIPTION
There are some issue with the current implementation

Some context:

1. I want to be able to do `castor up` and it must wait for all services to be ready 
(healthy)
1. Worker cannot be started on the very first boot, because code is not installed
2. So it must be set in another profile, and this profile must not be started by default
3. Docker build must be fixed, because we must build `worker` profile too by default
4. we cannot still use depends_on, profiles suck on this point