### PR TITLE
PHPStan level 8 compliance

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -38,7 +38,7 @@ function about(): void
 
     try {
         $routers = http_client()
-            ->request('GET', sprintf('http://%s:8080/api/http/routers', variable('root_domain')))
+            ->request('GET', \sprintf('http://%s:8080/api/http/routers', variable('root_domain')))
             ->toArray()
         ;
         $projectName = variable('project_name');
@@ -349,7 +349,7 @@ function create_default_context(): Context
         $data['power_shell'] = true;
     }
 
-    if ($data['user_id'] > 256000) {
+    if (false === $data['user_id'] || $data['user_id'] > 256000) {
         $data['user_id'] = 1000;
     }
 

--- a/.castor/init.php
+++ b/.castor/init.php
@@ -21,6 +21,11 @@ function init(): void
     fs()->rename('README.dist.md', 'README.md');
 
     $readMeContent = file_get_contents('README.md');
+
+    if (false === $readMeContent) {
+        return;
+    }
+
     $urls = [variable('root_domain'), ...variable('extra_domains')];
     $readMeContent = str_replace('<your hostnames>', implode(' ', $urls), $readMeContent);
     file_put_contents('README.md', $readMeContent);

--- a/castor.php
+++ b/castor.php
@@ -21,7 +21,7 @@ guard_min_version('0.18.0');
 import(__DIR__ . '/.castor');
 
 /**
- * @return array<string, mixed>
+ * @return array{project_name: string, root_domain: string, extra_domains: string[], php_version: string}
  */
 function create_default_variables(): array
 {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 8
     paths:
         # - application/src
         - application/public
@@ -28,7 +28,6 @@ parameters:
                 power_shell: bool,
                 user_id: int,
                 root_dir: string,
-                env: string,
                 composer_cache_dir: string,
             }
         '''


### PR DESCRIPTION
To fix:
```
------ ---------------------------------------------------------------------- 
  Line   .castor/docker.php                                                    
 ------ ---------------------------------------------------------------------- 
  362    Parameter #1 $data of class Castor\Context constructor expects        
         array{project_name: string, root_domain: string, extra_domains:       
         array<string>, project_directory: string, php_version: string,        
         docker_compose_files: array<string>, macos: bool, power_shell: bool,  
         ...}, non-empty-array<string, mixed> given.                           
 ------ ---------------------------------------------------------------------- 
 ```
 This may not be the cleanest way to do it, WDYT?