### PR TITLE
Do not mention PHP in requirements

### DIFF
--- a/README.dist.md
+++ b/README.dist.md
@@ -8,7 +8,6 @@ A Docker environment is provided and requires you to have these tools available:
 
  * Docker
  * Bash
- * PHP >= 8.1
  * [Castor](https://github.com/jolicode/castor#installation)
 
 #### Castor


### PR DESCRIPTION
Castor can be installed without PHP in some environment, so let's remove this requirement in docker-starter