### PR TITLE
fix: `cache-clear` task

### DIFF
--- a/castor.php
+++ b/castor.php
@@ -96,7 +96,8 @@ function cache_clear(): void
 {
     // io()->title('Clearing the application cache');
 
-    // docker_compose_run('rm -rf var/cache/ && bin/console cache:warmup');
+    // docker_compose_run('rm -rf var/cache/');
+    // docker_compose_run('bin/console cache:warmup');
 }
 
 #[AsTask(description: 'Migrates database schema', namespace: 'app:db', aliases: ['migrate'])]


### PR DESCRIPTION
The `docker_compose_run` function builds the following command: `... '/bin/sh' '-c' 'exec rm -rf var/cache/ && bin/console cache:warmup'`. The second part is ignored as `exec` replaces the current shell process, preventing any subsequent commands from being executed in the same context.

This is a quick fix, but maybe a fix at the command building level is preferable?