### PR TITLE
fix: `destroy` task

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -206,7 +206,7 @@ function destroy(
         }
     }
 
-    docker_compose(['down', '--remove-orphans', '--volumes', '--rmi=local'], withBuilder: true);
+    docker_compose(['down', '--remove-orphans', '--volumes', '--rmi=local'], withBuilder: true, profiles: ['default', 'worker']);
     $files = finder()
         ->in(variable('root_dir') . '/infrastructure/docker/services/router/certs/')
         ->name('*.pem')


### PR DESCRIPTION
@lbrunet encountered a problem when launching workers in `castor start` after using `castor destroy`. This seems to happen because the worker image is not destroyed:

![image](https://github.com/user-attachments/assets/3d8e4792-149f-43c5-aa42-fcaea638b4c3)