### PR TITLE
CI should run PHP-CS-Fixer in dry-run mode to exit with error code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
               run: "castor start"
 
             - name: "Check PHP coding standards"
-              run: "castor qa:cs"
+              run: "castor qa:cs --dry-run"
 
             - name: "Run PHPStan"
               run: "castor qa:phpstan"


### PR DESCRIPTION
Otherwise, CS failures are invisible