### PR TITLE
Remove useless `project_directory` variable

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -307,7 +307,6 @@ function create_default_context(): Context
         'project_name' => 'app',
         'root_domain' => 'app.test',
         'extra_domains' => [],
-        'project_directory' => 'application',
         'php_version' => '8.2',
         'docker_compose_files' => [
             'docker-compose.yml',

--- a/.castor/init.php
+++ b/.castor/init.php
@@ -34,7 +34,7 @@ function init(): void
 #[AsTask(description: 'Install Symfony')]
 function symfony(bool $webApp = false): void
 {
-    $base = rtrim(variable('root_dir') . '/' . variable('project_directory'), '/');
+    $base = rtrim(variable('root_dir') . '/application');
 
     $gitIgnore = $base . '/.gitignore';
     $gitIgnoreContent = '';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,7 +21,6 @@ parameters:
                 project_name: string,
                 root_domain: string,
                 extra_domains: string[],
-                project_directory: string,
                 php_version: string,
                 docker_compose_files: string[],
                 macos: bool,


### PR DESCRIPTION
This directory is hardcoded in the nginx and docker config as described in [the related cookbook](https://github.com/jolicode/docker-starter?tab=readme-ov-file#how-to-change-the-layout-of-the-project) 