### PR TITLE
Move the router to a new docker-compose.dev.yml

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -324,6 +324,7 @@ function create_default_context(): Context
         'php_version' => '8.2',
         'docker_compose_files' => [
             'docker-compose.yml',
+            'docker-compose.dev.yml',
         ],
         'docker_compose_run_environment' => [],
         'docker_compose_build_profiles' => [
@@ -381,6 +382,17 @@ function create_ci_context(): Context
         ->withData([
             // override the default context here
         ])
+        ->withData(
+            [
+                'docker_compose_files' => [
+                    'docker-compose.yml',
+                    // Usually, the following service is not be needed in the CI
+                    'docker-compose.dev.yml',
+                    // 'docker-compose.ci.yml',
+                ],
+            ],
+            recursive: false
+        )
         ->withEnvironment([
             'COMPOSE_ANSI' => 'never',
         ])

--- a/infrastructure/docker/docker-compose.dev.yml
+++ b/infrastructure/docker/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+services:
+    router:
+        build: services/router
+        volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
+            - "./services/router/certs:/etc/ssl/certs"
+        ports:
+            - "80:80"
+            - "443:443"
+            - "8080:8080"
+        networks:
+            - default
+        profiles:
+            - default

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -17,20 +17,6 @@ volumes:
     # builder-yarn-data: {}
 
 services:
-    router:
-        build: services/router
-        volumes:
-            - "/var/run/docker.sock:/var/run/docker.sock"
-            - "./services/router/certs:/etc/ssl/certs"
-        ports:
-            - "80:80"
-            - "443:443"
-            - "8080:8080"
-        networks:
-            - default
-        profiles:
-            - default
-
     postgres:
         image: postgres:16
         environment:


### PR DESCRIPTION
And this opens the gate for services only useful in dev (kibana, mail,
redis insight, encore, styleguide, etc)
