### PR TITLE
do not display title in dry run

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -550,7 +550,6 @@ function push(bool $dryRun = false): void
     }
 
     if ($dryRun) {
-        io()->title('Dry run: Displaying the generated bake file');
         io()->write($content);
 
         return;


### PR DESCRIPTION
Ref https://github.com/jolicode/docker-starter/pull/369#discussion_r2185678191

Goal is to allow piping the output to a file if we want, it's possible without the title and i don't think it bring that much value