### PR TITLE
Autocomplete --service option

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -68,6 +68,7 @@ function open_project(): void
 
 #[AsTask(description: 'Builds the infrastructure', aliases: ['build'])]
 function build(
+    #[AsOption(description: 'The service to build (default: all services)', autocomplete: 'docker\get_service_names')]
     ?string $service = null,
     ?string $profile = null,
 ): void {
@@ -103,6 +104,7 @@ function build(
  */
 #[AsTask(description: 'Builds and starts the infrastructure', aliases: ['up'])]
 function up(
+    #[AsOption(description: 'The service to start (default: all services)', autocomplete: 'docker\get_service_names')]
     ?string $service = null,
     #[AsOption(mode: InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED)]
     array $profiles = [],
@@ -133,6 +135,7 @@ function up(
  */
 #[AsTask(description: 'Stops the infrastructure', aliases: ['stop'])]
 function stop(
+    #[AsOption(description: 'The service to stop (default: all services)', autocomplete: 'docker\get_service_names')]
     ?string $service = null,
     #[AsOption(mode: InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED)]
     array $profiles = [],
@@ -576,4 +579,12 @@ function get_services(): array
         )->getOutput(),
         true,
     )['services'];
+}
+
+/**
+ * @return string[]
+ */
+function get_service_names(): array
+{
+    return array_keys(get_services());
 }

--- a/castor.php
+++ b/castor.php
@@ -15,7 +15,7 @@ use function docker\up;
 // use function docker\workers_start;
 // use function docker\workers_stop;
 
-guard_min_version('0.18.0');
+guard_min_version('0.26.0');
 
 import(__DIR__ . '/.castor');
 


### PR DESCRIPTION
```
>…ev/github.com/jolicode/docker-starter(autocomplete-de-malade) castor 
about                         castor:composer               docker:generate-certificates  help                          postgres                      start-workers
app:cache-clear               castor:execute                docker:logs                   init                          ps                            stop
app:cache-warmup              completion                    docker:ps                     install                       push                          stop-workers
app:db:fixtures               composer                      docker:push                   list                          qa:all                        symfony
app:db:migrate                cs                            docker:stop                   logs                          qa:cs                         twig-cs
app:install                   db:client                     docker:up                     migrate                       qa:install                    up
build                         destroy                       docker:worker:start           open                          qa:phpstan                    
builder                       docker:build                  docker:worker:stop            open-project                  qa:twig-cs                    
cache-clear                   docker:builder                execute                       pg                            qa:update                     
cache-warmup                  docker:destroy                fixture                       phpstan                       start                         
>…ev/github.com/jolicode/docker-starter(autocomplete-de-malade) castor docker:
build                  destroy                logs                   push                   up                     worker:stop            
builder                generate-certificates  ps                     stop                   worker:start           
>…ev/github.com/jolicode/docker-starter(autocomplete-de-malade) castor docker:build --
--ansi            --help            --no-interaction  --profile         --service         --update-remotes  --version         
--context         --no-ansi         --no-remote       --quiet           --silent          --verbose         
>…ev/github.com/jolicode/docker-starter(autocomplete-de-malade) castor docker:build --service 
builder   frontend  postgres  router   
```
