### PR TITLE
Remove useless phpstan config

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,9 +12,6 @@ parameters:
     tmpDir: tools/phpstan/var
     inferPrivatePropertyTypeFromConstructor: true
 
-    # symfony:
-    #     containerXmlPath: 'application/var/cache/dev/App_KernelDevDebugContainer.xml'
-
     typeAliases:
         ContextData: '''
             array{


### PR DESCRIPTION
It's not used nowadays with phpstan/phpstan-symfony.