### PR TITLE
Really fix the builder command when no TTY is available

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -165,6 +165,8 @@ function builder(#[AsRawTokens] array $params = []): int
     if (0 === \count($params)) {
         $params = ['bash'];
         $c = $c->toInteractive();
+    } else {
+        $c = $c->withTty(false)->withPty(false)->withAllowFailure();
     }
 
     return (int) docker_compose_run(implode(' ', $params), c: $c)->getExitCode();


### PR DESCRIPTION
PTY, TTY stuff are hard !
<img width="1728" height="1078" alt="Screenshot From 2026-05-27 18-09-00" src="https://github.com/user-attachments/assets/c3888a73-1c27-4258-93f6-c33f6a1b17df" />
