### PR TITLE
Silent docker when running ephemeral container

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -418,6 +418,7 @@ function docker_compose_run(
     $command = [
         'run',
         '--rm',
+        '--quiet',
     ];
 
     if ($noDeps) {


### PR DESCRIPTION
```
>…ire/dev/github.com/jolicode/docker-starter(docker-compose-run-quiet) castor builder -- php -v
 Container app-builder-run-0113aa77839c Creating 
 Container app-builder-run-0113aa77839c Created 
PHP 8.5.6 (cli) (built: May 14 2026 15:46:20) (NTS)
Copyright (c) The PHP Group
Built by Debian
Zend Engine v4.5.6, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.6, Copyright (c), by Zend Technologies
>…ire/dev/github.com/jolicode/docker-starter(docker-compose-run-quiet) # Après le patch
>…ire/dev/github.com/jolicode/docker-starter(docker-compose-run-quiet *) castor builder -- php -v
PHP 8.5.6 (cli) (built: May 14 2026 15:46:20) (NTS)
Copyright (c) The PHP Group
Built by Debian
Zend Engine v4.5.6, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.6, Copyright (c), by Zend Technologies
```
