### PR TITLE
Refactor how we use run() docker command

### DIFF
--- a/.castor/docker.php
+++ b/.castor/docker.php
@@ -175,22 +175,14 @@ function stop(
 }
 
 /**
- * @param array<string> $params
+ * @param list<string> $params
  */
 #[AsTask(description: 'Opens a shell (bash) or proxy any command to the builder container', aliases: ['builder'])]
 function builder(#[AsArgsAfterOptionEnd] array $params = []): int
 {
-    $c = context()->withEnvironment($_ENV + $_SERVER);
+    $context = context()->withEnvironment($_ENV + $_SERVER);
 
-    if (0 === \count($params)) {
-        $params = ['bash'];
-        $c = $c->toInteractive();
-    } else {
-        $c = $c->withTty(false)->withPty(false)->withInput(STDIN)->withAllowFailure();
-        $params = array_map(escapeshellarg(...), $params);
-    }
-
-    return (int) docker_compose_run(implode(' ', $params), c: $c)->getExitCode();
+    return (int) docker_compose_run($params, $context)->getExitCode();
 }
 
 /**
@@ -435,8 +427,11 @@ function docker_compose(array $subCommand, ?Context $c = null, array $profiles =
     return run($command, context: $c);
 }
 
+/**
+ * @param list<string> $params
+ */
 function docker_compose_run(
-    string $runCommand,
+    array $params,
     ?Context $c = null,
     string $service = 'builder',
     bool $noDeps = true,
@@ -469,16 +464,57 @@ function docker_compose_run(
         $command[] = "{$key}={$value}";
     }
 
+    if (0 === \count($params)) {
+        $params = ['bash'];
+        $c = $c->toInteractive();
+    } else {
+        $c = $c->withTty(false)->withPty(false)->withInput(STDIN)->withAllowFailure();
+        $params = array_map(escapeshellarg(...), $params);
+    }
+
     $command[] = $service;
     $command[] = '/bin/bash';
     $command[] = '-c';
-    $command[] = "{$runCommand}";
+    $command[] = implode(' ', $params);
 
     return docker_compose($command, c: $c, profiles: ['*']);
 }
 
+/**
+ * @param list<string> $params
+ */
+function docker_compose_exec(
+    array $params,
+    ?Context $context = null,
+    string $service = 'builder',
+): Process {
+    $context ??= context();
+
+    $command = [
+        'exec',
+    ];
+
+    if (0 === \count($params)) {
+        $params = ['bash'];
+        $context = $context->toInteractive();
+    } else {
+        $context = $context->withTty(false)->withPty(false)->withInput(STDIN)->withAllowFailure();
+        $params = array_map(escapeshellarg(...), $params);
+    }
+
+    $command[] = $service;
+    $command[] = '/bin/bash';
+    $command[] = '-c';
+    $command[] = implode(' ', $params);
+
+    return docker_compose($command, c: $context, profiles: ['*']);
+}
+
+/**
+ * @param list<string> $params
+ */
 function docker_exit_code(
-    string $runCommand,
+    array $params,
     ?Context $c = null,
     string $service = 'builder',
     bool $noDeps = true,
@@ -487,7 +523,7 @@ function docker_exit_code(
     $c = ($c ?? context())->withAllowFailure();
 
     $process = docker_compose_run(
-        runCommand: $runCommand,
+        params: $params,
         c: $c,
         service: $service,
         noDeps: $noDeps,
@@ -495,19 +531,6 @@ function docker_exit_code(
     );
 
     return $process->getExitCode() ?? 0;
-}
-
-// Mac users have a lot of problems running Yarn / Webpack on the Docker stack
-// so this func allow them to run these tools on their host
-function run_in_docker_or_locally_for_mac(string $command, ?Context $c = null): void
-{
-    $c ??= context();
-
-    if ($c['macos']) {
-        run($command, context: $c->withWorkingDirectory($c['root_dir']));
-    } else {
-        docker_compose_run($command, c: $c);
-    }
 }
 
 #[AsTask(description: 'Push images cache to the registry', namespace: 'docker', name: 'push', aliases: ['push'])]

--- a/.castor/init.php
+++ b/.castor/init.php
@@ -44,16 +44,16 @@ function symfony(bool $webApp = false): void
     }
 
     build();
-    docker_compose_run('composer create-project symfony/skeleton sf');
+    docker_compose_run(['composer', 'create-project', 'symfony/skeleton', 'sf']);
 
     fs()->mirror($base . '/sf/', $base, options: ['override' => true]);
     fs()->remove([$base . '/sf', $base . '/var']);
 
     if ($webApp) {
-        docker_compose_run('composer require webapp');
+        docker_compose_run(['composer', 'require', 'webapp']);
     }
 
-    docker_compose_run("sed -i 's#^DATABASE_URL.*#DATABASE_URL=postgresql://app:app@postgres:5432/app\\?serverVersion=16\\&charset=utf8#' .env");
+    docker_compose_run(['sed', '-i', 's#^DATABASE_URL.*#DATABASE_URL=postgresql://app:app@postgres:5432/app\?serverVersion=16\&charset=utf8#', '.env']);
     file_put_contents($gitIgnore, $gitIgnoreContent, \FILE_APPEND);
 }
 
@@ -69,12 +69,12 @@ function sylius(): void
     }
 
     build();
-    docker_compose_run('composer create-project sylius/sylius-standard sylius');
+    docker_compose_run(['composer', 'create-project', 'sylius/sylius-standard', 'sylius']);
 
     fs()->mirror($base . '/sylius/', $base, options: ['override' => true]);
     fs()->remove([$base . '/sylius', $base . '/var']);
 
-    docker_compose_run("sed -i 's#^DATABASE_URL.*#DATABASE_URL=postgresql://app:app@postgres:5432/app\\?serverVersion=16\\&charset=utf8#' .env");
+    docker_compose_run(['sed', '-i', 's#^DATABASE_URL.*#DATABASE_URL=postgresql://app:app@postgres:5432/app\?serverVersion=16\&charset=utf8#', '.env']);
     file_put_contents($gitIgnore, $gitIgnoreContent, \FILE_APPEND);
 
     chrome();

--- a/.castor/qa.php
+++ b/.castor/qa.php
@@ -27,9 +27,9 @@ function install(): void
 {
     io()->title('Installing QA tooling');
 
-    docker_compose_run('composer install -o', workDir: '/var/www/tools/php-cs-fixer');
-    docker_compose_run('composer install -o', workDir: '/var/www/tools/phpstan');
-    docker_compose_run('composer install -o', workDir: '/var/www/tools/twig-cs-fixer');
+    docker_compose_run(['composer', 'install', '-o'], workDir: '/var/www/tools/php-cs-fixer');
+    docker_compose_run(['composer', 'install', '-o'], workDir: '/var/www/tools/phpstan');
+    docker_compose_run(['composer', 'install', '-o'], workDir: '/var/www/tools/twig-cs-fixer');
 }
 
 #[AsTask(description: 'Updates tooling')]
@@ -37,13 +37,13 @@ function update(): void
 {
     io()->title('Updating QA tooling');
 
-    docker_compose_run('composer update -o', workDir: '/var/www/tools/php-cs-fixer');
-    docker_compose_run('composer update -o', workDir: '/var/www/tools/phpstan');
-    docker_compose_run('composer update -o', workDir: '/var/www/tools/twig-cs-fixer');
+    docker_compose_run(['composer', 'update', '-o'], workDir: '/var/www/tools/php-cs-fixer');
+    docker_compose_run(['composer', 'update', '-o'], workDir: '/var/www/tools/phpstan');
+    docker_compose_run(['composer', 'update', '-o'], workDir: '/var/www/tools/twig-cs-fixer');
 }
 
 /**
- * @param string[] $rawTokens
+ * @param list<string> $rawTokens
  */
 #[AsTask(description: 'Runs PHPUnit', aliases: ['phpunit'])]
 function phpunit(#[AsRawTokens] array $rawTokens = []): int
@@ -54,7 +54,7 @@ function phpunit(#[AsRawTokens] array $rawTokens = []): int
 
     io()->section('Running PHPUnit...');
 
-    return docker_exit_code('vendor/bin/phpunit ' . implode(' ', $rawTokens));
+    return docker_exit_code(['vendor/bin/phpunit', ...$rawTokens]);
 }
 
 #[AsTask(description: 'Runs PHPStan', aliases: ['phpstan'])]
@@ -68,8 +68,10 @@ function phpstan(
 
     io()->section('Running PHPStan...');
 
-    $options = $baseline ? '--generate-baseline --allow-empty-baseline' : '';
-    $command = \sprintf('phpstan analyse --memory-limit=-1 %s -v', $options);
+    $command = ['phpstan', 'analyse', '--memory-limit=-1', '-v'];
+    if ($baseline) {
+        $command = [...$command, '--generate-baseline', '--allow-empty-baseline'];
+    }
 
     return docker_exit_code($command, workDir: '/var/www');
 }
@@ -82,7 +84,7 @@ function securityAudit(): int
     if (is_file("{$basePath}/composer.lock")) {
         io()->text('Running Composer audit...');
 
-        $exitCode = docker_exit_code('composer audit');
+        $exitCode = docker_exit_code(['composer', 'audit']);
 
         if (0 !== $exitCode) {
             return $exitCode;
@@ -92,7 +94,7 @@ function securityAudit(): int
     if (is_file("{$basePath}/yarn.lock")) {
         io()->text('Running Yarn audit...');
 
-        $exitCode = docker_exit_code('yarn audit');
+        $exitCode = docker_exit_code(['yarn', 'audit']);
 
         if (0 !== $exitCode) {
             return $exitCode;
@@ -102,7 +104,7 @@ function securityAudit(): int
     if (is_file("{$basePath}/package-lock.json")) {
         io()->text('Running NPM audit...');
 
-        return docker_exit_code('npm audit');
+        return docker_exit_code(['npm', 'audit']);
     }
 
     return 0;
@@ -118,10 +120,10 @@ function cs(bool $dryRun = false): int
     io()->section('Running PHP CS Fixer...');
 
     if ($dryRun) {
-        return docker_exit_code('php-cs-fixer fix --dry-run --diff', workDir: '/var/www');
+        return docker_exit_code(['php-cs-fixer', 'fix', '--dry-run', '--diff'], workDir: '/var/www');
     }
 
-    return docker_exit_code('php-cs-fixer fix -v', workDir: '/var/www');
+    return docker_exit_code(['php-cs-fixer', 'fix', '-v'], workDir: '/var/www');
 }
 
 #[AsTask(description: 'Fixes Twig Coding Style', aliases: ['twig-cs'])]
@@ -134,8 +136,8 @@ function twigCs(bool $dryRun = false): int
     io()->section('Running Twig CS Fixer...');
 
     if ($dryRun) {
-        return docker_exit_code('twig-cs-fixer', workDir: '/var/www');
+        return docker_exit_code(['twig-cs-fixer'], workDir: '/var/www');
     }
 
-    return docker_exit_code('twig-cs-fixer --fix', workDir: '/var/www');
+    return docker_exit_code(['twig-cs-fixer', '--fix'], workDir: '/var/www');
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,13 @@ jobs:
                   #[AsTask()]
                   function test()
                   {
-                      docker_compose_run('echo "Hello World"');
+                      docker_compose_run(['echo', 'Hello World']);
                   }
 
                   #[AsTask()]
                   function app_env()
                   {
-                      docker_compose_run('php public/index.php');
+                      docker_compose_run(['php', 'public/index.php']);
                   }
                   EOPHP
 

--- a/castor.php
+++ b/castor.php
@@ -67,23 +67,23 @@ function install(): void
 
     if (is_file("{$basePath}/composer.json")) {
         io()->section('Installing PHP dependencies');
-        docker_compose_run('composer install -n --prefer-dist --optimize-autoloader');
+        docker_compose_run(['composer', 'install', '-n', '--prefer-dist', '--optimize-autoloader']);
     }
     if (is_file("{$basePath}/yarn.lock")) {
         io()->section('Installing Node.js dependencies');
-        docker_compose_run('yarn install --immutable');
+        docker_compose_run(['yarn', 'install', '--immutable']);
     } elseif (is_file("{$basePath}/package.json")) {
         io()->section('Installing Node.js dependencies');
 
         if (is_file("{$basePath}/package-lock.json")) {
-            docker_compose_run('npm ci');
+            docker_compose_run(['npm', 'ci']);
         } else {
-            docker_compose_run('npm install');
+            docker_compose_run(['npm', 'install']);
         }
     }
     if (is_file("{$basePath}/importmap.php")) {
         io()->section('Installing importmap');
-        docker_compose_run('bin/console importmap:install');
+        docker_compose_run(['bin/console', 'importmap:install']);
     }
 
     qa\install();
@@ -94,7 +94,7 @@ function update(bool $withTools = false): void
 {
     io()->title('Updating dependencies...');
 
-    // docker_compose_run('composer update -o');
+    // docker_compose_run(['composer', 'update', '-o']);
 
     if ($withTools) {
         qa\update();
@@ -106,7 +106,7 @@ function cache_clear(bool $warm = true): void
 {
     // io()->title('Clearing the application cache');
 
-    // docker_compose_run('rm -rf var/cache/');
+    // docker_compose_run(['rm', '-rf', 'var/cache/']);
 
     // if ($warm) {
     //     cache_warmup();
@@ -118,7 +118,7 @@ function cache_warmup(): void
 {
     // io()->title('Warming the application cache');
 
-    // docker_compose_run('bin/console cache:warmup', c: context()->withAllowFailure());
+    // docker_compose_run(['bin/console', 'cache:warmup'], c: context()->withAllowFailure());
 }
 
 #[AsTask(description: 'Migrates database schema', namespace: 'app:db', aliases: ['migrate'])]
@@ -126,8 +126,8 @@ function migrate(): void
 {
     // io()->title('Migrating the database schema');
 
-    // docker_compose_run('bin/console doctrine:database:create --if-not-exists');
-    // docker_compose_run('bin/console doctrine:migration:migrate -n --allow-no-migration --all-or-nothing');
+    // docker_compose_run(['bin/console', 'doctrine:database:create', '--if-not-exists']);
+    // docker_compose_run(['bin/console', 'doctrine:migration:migrate', '-n', '--allow-no-migration', '--all-or-nothing']);
 }
 
 #[AsTask(description: 'Loads fixtures', namespace: 'app:db', aliases: ['fixtures'])]
@@ -136,7 +136,7 @@ function fixtures(): void
     // io()->title('Loads fixtures');
 
     // Uncomment one of them...
-    // docker_compose_run('bin/console doctrine:fixture:load -n');
-    // docker_compose_run('bin/console foundry:load-fixtures -n');
-    // docker_compose_run('bin/console sylius:fixture:load -n');
+    // docker_compose_run(['bin/console', 'doctrine:fixture:load', '-n']);
+    // docker_compose_run(['bin/console', 'foundry:load-fixtures', '-n']);
+    // docker_compose_run(['bin/console', 'sylius:fixture:load', '-n']);
 }


### PR DESCRIPTION
1. use array insteand of string, it's more secure, and easier to
   manipulate data
2. move many code from the builder to to the run() command
3. add an exec() command
4. and remove run_in_docker_or_locally_for_mac, not used anymore

> I did that, because I needed exec() on another project, and the logic between run and exec are very close