### PR TITLE
Allow running one-shot psql commands via castor pg

### DIFF
--- a/.castor/postgres.php
+++ b/.castor/postgres.php
@@ -11,6 +11,14 @@ use function docker\docker_compose;
 use function docker\docker_compose_exec;
 
 /**
+ * Same idea as "castor builder -- <command>": proxies anything after "--" to
+ * psql inside the postgres container, in a non-interactive way with the exit
+ * code propagated.
+ *
+ * castor pg                          # interactive psql
+ * castor pg -- "SELECT now();"       # one-shot query
+ * castor pg -- -c "\dt"              # raw psql arguments
+ *
  * @param list<string> $params
  */
 #[AsTask(description: 'Connect to the PostgreSQL database', aliases: ['postgres', 'pg'])]

--- a/.castor/postgres.php
+++ b/.castor/postgres.php
@@ -2,16 +2,35 @@
 
 namespace postgres;
 
+use Castor\Attribute\AsArgsAfterOptionEnd;
 use Castor\Attribute\AsTask;
 
 use function Castor\context;
 use function Castor\io;
 use function docker\docker_compose;
+use function docker\docker_compose_exec;
 
+/**
+ * @param list<string> $params
+ */
 #[AsTask(description: 'Connect to the PostgreSQL database', aliases: ['postgres', 'pg'])]
-function client(): void
+function client(#[AsArgsAfterOptionEnd] array $params = []): int
 {
-    io()->title('Connecting to the PostgreSQL database');
+    $command = ['psql', '-U', 'app', 'app'];
 
-    docker_compose(['exec', 'postgres', 'psql', '-U', 'app', 'app'], context()->toInteractive());
+    if (!$params) {
+        io()->title('Connecting to the PostgreSQL database');
+
+        docker_compose(['exec', 'postgres', ...$command], context()->toInteractive());
+
+        return 0;
+    }
+
+    // Rebuild the query as a single psql argument, as the shell splits it
+    // into multiple words ("castor pg -- SELECT 1;" gives ['SELECT', '1;'])
+    if (!str_starts_with((string) reset($params), '-')) {
+        $params = ['-c', implode(' ', $params)];
+    }
+
+    return (int) docker_compose_exec([...$command, ...$params], service: 'postgres')->getExitCode();
 }

--- a/README.md
+++ b/README.md
@@ -969,7 +969,7 @@ Then, you can add the following content to the `castor.php` file:
 #[AsTask(description: 'Monitor PostgreSQL', namespace: 'app:db')]
 function pg_activity(): void
 {
-    docker_compose('exec postgres pg_activity -U app');
+    docker_compose(['exec', 'postgres', 'pg_activity', '-U', 'app');
 }
 ```
 


### PR DESCRIPTION
Same idea as `castor builder -- <command>`: the `castor pg` task now accepts anything after `--` and proxies it to `psql` inside the postgres container, in a non-interactive way with the exit code propagated. This makes it easy for agents (and humans) to run queries:

```
castor pg                          # interactive psql (unchanged)
castor pg -- "SELECT now();"       # one-shot query
castor pg -- -c "\dt"              # raw psql arguments
```

If the first argument is not an option (does not start with `-`), the words are re-joined into a single psql `-c` argument, as the shell splits them into multiple argv entries.