### PR TITLE
fix(PostgreSQL): switch healthcheck user to 'app'

### DIFF
--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         volumes:
             - postgres-data:/var/lib/postgresql/data
         healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            test: ["CMD-SHELL", "pg_isready -U app"]
             interval: 5s
             timeout: 5s
             retries: 5


### PR DESCRIPTION
The healthcheck was done on the wrong user, resulting in a never ready postgres.

> postgres-1  | 2026-09-08 11:31:49.611 UTC [165] FATAL:  role "postgres" does not exist